### PR TITLE
linux-rockpi: Add SCSI GENERIC driver for the Rockpi 4B

### DIFF
--- a/layers/meta-balena-rockpi/recipes-kernel/linux/linux-rockpi-4_%.bbappend
+++ b/layers/meta-balena-rockpi/recipes-kernel/linux/linux-rockpi-4_%.bbappend
@@ -31,3 +31,8 @@ BALENA_CONFIGS_DEPS[backported-brcmfmac] += " \
     CONFIG_X509_CERTIFICATE_PARSER=y \
     CONFIG_PKCS7_MESSAGE_PARSER=y \
 "
+
+BALENA_CONFIGS_append_rockpi-4b-rk3399 = " scsi-generic"
+BALENA_CONFIGS[scsi-generic] = " \
+    CONFIG_CHR_DEV_SG=m \
+"


### PR DESCRIPTION
This module is needed by the autokit

Changelog-entry: linux-rockpi: Add SCSI GENERIC driver for the Rockpi 4B