### PR TITLE
linux-rockpi: Add scsi-generic driver

### DIFF
--- a/layers/meta-balena-rockpi/recipes-kernel/linux/linux-rockpi-4_%.bbappend
+++ b/layers/meta-balena-rockpi/recipes-kernel/linux/linux-rockpi-4_%.bbappend
@@ -13,6 +13,11 @@ BALENA_CONFIGS[no-in-tree_wifi-no-rockchip-wl] = " \
     CONFIG_WL_ROCKCHIP=n \
 "
 
+BALENA_CONFIGS_append_rockpi-4b-rk3399 = " scsi-generic"
+BALENA_CONFIGS[scsi-generic] = " \
+    CONFIG_CHR_DEV_SG=m \
+"
+
 # we need some deps for the backported brcmfmac driver as per the README of the brcmfmac backport from Infineon
 BALENA_CONFIGS_append_rockpi-4b-rk3399 = " backported-brcmfmac"
 


### PR DESCRIPTION
Changelog-entry: linux-rockpi: Add scsi-generic driver

so the sd-mux can be used on this DT

Replaces https://github.com/balena-os/balena-radxa/pull/338