### PR TITLE
Explicitly set GITHUB_TOKEN permissions for yocto workflow

### DIFF
--- a/.github/workflows/radxa-cm3-io-rk3566.yml
+++ b/.github/workflows/radxa-cm3-io-rk3566.yml
@@ -36,6 +36,12 @@ on:
         type: string
         default: ''
 
+permissions:
+  id-token: write # This is required for requesting the JWT #https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services#requesting-the-access-token
+  actions: read # We are fetching workflow run results of a merge commit when workflow is triggered by new tag, to see if tests pass
+  pull-requests: write # Read is required to fetch the PR that merged, in order to get the test results. Write is required to create PR comments for workflow approvals.
+  packages: read
+  contents: read
 
 jobs:
   yocto:

--- a/.github/workflows/radxa-zero-s905y2.yml
+++ b/.github/workflows/radxa-zero-s905y2.yml
@@ -36,6 +36,12 @@ on:
         type: string
         default: ''
 
+permissions:
+  id-token: write # This is required for requesting the JWT #https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services#requesting-the-access-token
+  actions: read # We are fetching workflow run results of a merge commit when workflow is triggered by new tag, to see if tests pass
+  pull-requests: write # Read is required to fetch the PR that merged, in order to get the test results. Write is required to create PR comments for workflow approvals.
+  packages: read
+  contents: read
 
 jobs:
   yocto:

--- a/.github/workflows/rockpi-4b-rk3399.yml
+++ b/.github/workflows/rockpi-4b-rk3399.yml
@@ -36,6 +36,12 @@ on:
         type: string
         default: ''
 
+permissions:
+  id-token: write # This is required for requesting the JWT #https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services#requesting-the-access-token
+  actions: read # We are fetching workflow run results of a merge commit when workflow is triggered by new tag, to see if tests pass
+  pull-requests: write # Read is required to fetch the PR that merged, in order to get the test results. Write is required to create PR comments for workflow approvals.
+  packages: read
+  contents: read
 
 jobs:
   yocto:


### PR DESCRIPTION
Changelog-entry: Explicitly set GITHUB_TOKEN permissions for yocto workflow