### PR TITLE
rkwifibt-firmware.bb: Use nonarch_base_libdir variable to change inst…

### DIFF
--- a/layers/meta-balena-rockpi/conf/samples/local.conf.sample
+++ b/layers/meta-balena-rockpi/conf/samples/local.conf.sample
@@ -5,9 +5,6 @@
 
 BALENA_STORAGE = "overlay2"
 
-# this does not compile at the moment so let's disable it
-BALENA_DISABLE_KERNEL_HEADERS = "1"
-
 # More info meta-resin/README.md
 #TARGET_REPOSITORY ?= ""
 #TARGET_TAG ?= ""

--- a/layers/meta-balena-rockpi/recipes-core/bluetooth/bluetooth-broadcom.bb
+++ b/layers/meta-balena-rockpi/recipes-core/bluetooth/bluetooth-broadcom.bb
@@ -1,0 +1,34 @@
+SUMMARY = "Systemd service to setup BT for Broadcom Bluetooth chips"
+DESCRIPTION = "Load Broadcom Bluetooth Chips Firmware"
+SECTION = "devel"
+
+LICENSE = "GPLv2"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/GPL-2.0;md5=801f80980d171dd6425610833a22dbe6"
+
+SRC_URI = " \
+	file://broadcom-bluetooth/99-brcm-btfw-load.rules;name=brcm-btfw-load-rules \
+	file://broadcom-bluetooth/brcm-btfw-load.sh;name=brcm-btfw-load-script \
+	file://broadcom-bluetooth/brcm-btfw-load@.service;name=brcm-btfw-load-service \
+"
+SRC_URI[brcm-btfw-load-rules.md5sum] = "d22a83ca506f9991fda270922340ea35"
+SRC_URI[brcm-btfw-load-script.md5sum] = "f42f9149890c3e53c19be4acf3b65268"
+SRC_URI[brcm-btfw-load-service.md5sum] = "9408dcc71c940db2cc0319483bbf6122"
+
+inherit systemd
+
+RDEPENDS_${PN} += "bluez5"
+
+do_install() {
+	install -d ${D}${systemd_system_unitdir}
+	install -d ${D}${bindir}
+	install -d ${D}/${nonarch_base_libdir}/udev/rules.d
+	install -m 0644 ${WORKDIR}/broadcom-bluetooth/brcm-btfw-load@.service ${D}${systemd_system_unitdir}
+	install -m 0644 ${WORKDIR}/broadcom-bluetooth/99-brcm-btfw-load.rules ${D}/${nonarch_base_libdir}/udev/rules.d
+	install -m 0755 ${WORKDIR}/broadcom-bluetooth/brcm-btfw-load.sh ${D}${bindir}/brcm-btfw-load.sh
+}
+
+FILES_${PN} = " \
+  ${nonarch_base_libdir}/udev/rules.d/99-brcm-btfw-load.rules \
+  ${nonarch_base_libdir}/systemd/system/brcm-btfw-load@.service \
+  /usr/bin/brcm-btfw-load.sh \
+"

--- a/layers/meta-balena-rockpi/recipes-core/bluetooth/files/broadcom-bluetooth/99-brcm-btfw-load.rules
+++ b/layers/meta-balena-rockpi/recipes-core/bluetooth/files/broadcom-bluetooth/99-brcm-btfw-load.rules
@@ -1,0 +1,1 @@
+ACTION=="add", KERNEL=="*:*:1", SUBSYSTEM=="sdio", ATTR{vendor}=="0x02d0", TAG+="systemd", ENV{SYSTEMD_WANTS}="brcm-btfw-load@%k.service"

--- a/layers/meta-balena-rockpi/recipes-core/bluetooth/files/broadcom-bluetooth/brcm-btfw-load.sh
+++ b/layers/meta-balena-rockpi/recipes-core/bluetooth/files/broadcom-bluetooth/brcm-btfw-load.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+FIRMWARE="/lib/firmware/brcm"
+
+DEVICE=$(cat /sys/bus/sdio/devices/$1/device)
+echo "DEVICE=$DEVICE"
+
+BT_UART="$(strings /sys/firmware/fdt | grep bt_uart)"
+if [[ -n ${BT_UART} ]]; then
+    NUMBER=$(echo "${BT_UART}" | cut -d "_" -f2 | cut -d "t" -f2)
+    BT_UART="/dev/ttyS${NUMBER}"
+else
+    exit 0
+fi
+echo "BT_UART: ${BT_UART}"
+
+# ap6212
+if [[ "$DEVICE" == "0xa9a6" ]]; then
+    FIRMWARE="$FIRMWARE/bcm43438a1.hcd"
+    echo "load ap6212 bt firmware"
+# ap6256
+elif [[ "$DEVICE" == "0xa9bf" ]]; then
+    FIRMWARE="$FIRMWARE/BCM4345C5.hcd"
+    echo "load ap6256 bt firmware"
+# ap6398s
+elif [[ "$DEVICE" == "0x4359" ]]; then
+    FIRMWARE="$FIRMWARE/BCM4359C0.hcd"
+    echo "load ap6398s bt firmware"
+fi
+
+/usr/bin/brcm_patchram_plus --enable_hci --no2bytes --use_baudrate_for_download --tosleep 200000 --baudrate 1500000 --patchram ${FIRMWARE} ${BT_UART}

--- a/layers/meta-balena-rockpi/recipes-core/bluetooth/files/broadcom-bluetooth/brcm-btfw-load@.service
+++ b/layers/meta-balena-rockpi/recipes-core/bluetooth/files/broadcom-bluetooth/brcm-btfw-load@.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Load Bluetooth firmware
+
+[Service]
+Type=oneshot
+ExecStartPre=/usr/sbin/rfkill unblock bluetooth
+ExecStart=/bin/bash /usr/bin/brcm-btfw-load.sh %I
+
+[Install]
+WantedBy=multi-user.target

--- a/layers/meta-balena-rockpi/recipes-kernel/rkwifibt-firmware/rkwifibt-firmware.bb
+++ b/layers/meta-balena-rockpi/recipes-kernel/rkwifibt-firmware/rkwifibt-firmware.bb
@@ -1,0 +1,142 @@
+# Copyright (C) 2019, Fuzhou Rockchip Electronics Co., Ltd
+
+SUMMARY = "Rockchip WIFI/BT firmware files"
+SECTION = "kernel"
+
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://NOTICE;md5=9645f39e9db895a4aa6e02cb57294595"
+
+SRCREV = "3277c78514fce8964c25172a5e8c7102bd0c17f6"
+SRC_URI = "git://github.com/radxa/rkwifibt.git;protocol=https"
+
+S = "${WORKDIR}/git"
+
+inherit allarch deploy
+
+do_install() {
+	install -d ${D}/${nonarch_base_libdir}/firmware/brcm/
+	install -m 0644 ${S}/firmware/broadcom/AW-NB197/bt/BCM4343A1_001.002.009.1008.1024.hcd \
+		${D}/${nonarch_base_libdir}/firmware/brcm/bcm43438a1.hcd
+	install -m 0644 ${S}/firmware/broadcom/AP6236/*/* \
+		-t ${D}/${nonarch_base_libdir}/firmware/brcm/
+	install -m 0644 ${S}/firmware/broadcom/AP6255/*/* \
+		-t ${D}/${nonarch_base_libdir}/firmware/brcm/
+	install -m 0644 ${S}/firmware/broadcom/AP6256/bt/* \
+		-t ${D}/${nonarch_base_libdir}/firmware/brcm/
+	install -m 0644 ${S}/firmware/broadcom/AP6256/wifi/fw_bcm43456c5_ag.bin \
+		${D}/${nonarch_base_libdir}/firmware/brcm/brcmfmac43456-sdio.bin
+	install -m 0644 ${S}/firmware/broadcom/AP6256/wifi/nvram_ap6256.txt \
+		${D}/${nonarch_base_libdir}/firmware/brcm/brcmfmac43456-sdio.txt
+	install -m 0644 ${S}/firmware/broadcom/AP6356/*/* \
+		-t ${D}/${nonarch_base_libdir}/firmware/brcm/
+	install -m 0644 ${S}/firmware/broadcom/AP6398S/*/* \
+		-t ${D}/${nonarch_base_libdir}/firmware/brcm/
+
+	# let's use the firmware for AP6212 from Infineon / Cypress
+	install -m 0644 ${S}/firmware/cypress/wifi/cyfmac43430-sdio.bin ${D}/${nonarch_base_libdir}/firmware/brcm/brcmfmac43430-sdio.bin
+	install -m 0644 ${S}/firmware/cypress/wifi/cyfmac43430-sdio.txt ${D}/${nonarch_base_libdir}/firmware/brcm/brcmfmac43430-sdio.txt
+	install -m 0644 ${S}/firmware/cypress/wifi/cyfmac43430-sdio.clm_blob ${D}/${nonarch_base_libdir}/firmware/brcm/brcmfmac43430-sdio.clm_blob
+
+	install -d ${D}${nonarch_base_libdir}/firmware/rtlbt/
+	install -m 0644 ${S}/realtek/RTL8723DS/* -t ${D}${nonarch_base_libdir}/firmware/rtlbt/
+	install -m 0644 ${S}/realtek/RTL8723DU/* -t ${D}${nonarch_base_libdir}/firmware/
+	install -m 0644 ${S}/realtek/RTL8821CU/* -t ${D}${nonarch_base_libdir}/firmware/
+}
+
+PACKAGES =+ " \
+	${PN}-ap6212a1-wifi \
+	${PN}-ap6212a1-bt \
+	${PN}-ap6236-wifi \
+	${PN}-ap6236-bt \
+	${PN}-ap6255-wifi \
+	${PN}-ap6255-bt \
+	${PN}-ap6256-wifi \
+	${PN}-ap6256-bt \
+	${PN}-ap6356-wifi \
+	${PN}-ap6356-bt \
+	${PN}-ap6398s-wifi \
+	${PN}-ap6398s-bt \
+	${PN}-rtl8723ds-bt \
+	${PN}-rtl8723du-bt \
+	${PN}-rtl8821cu-bt \
+"
+
+FILES_${PN}-ap6212a1-wifi = " \
+	${nonarch_base_libdir}/firmware/brcm/brcmfmac43430-sdio* \
+"
+
+FILES_${PN}-ap6212a1-bt = " \
+	${nonarch_base_libdir}/firmware/brcm/bcm43438a1.hcd \
+"
+
+FILES_${PN}-ap6236-wifi = " \
+	${nonarch_base_libdir}/firmware/brcm/fw_bcm43436b0.bin \
+	${nonarch_base_libdir}/firmware/brcm/nvram_ap6236.txt \
+"
+
+FILES_${PN}-ap6236-bt = " \
+	${nonarch_base_libdir}/firmware/brcm/BCM4343B0.hcd \
+"
+
+FILES_${PN}-ap6255-wifi = " \
+	${nonarch_base_libdir}/firmware/brcm/fw_bcm43455c0_ag.bin \
+	${nonarch_base_libdir}/firmware/brcm/fw_bcm43455c0_ag_p2p.bin \
+	${nonarch_base_libdir}/firmware/brcm/nvram_ap6255.txt \
+"
+
+FILES_${PN}-ap6255-bt = " \
+	${nonarch_base_libdir}/firmware/brcm/BCM4345C0.hcd \
+"
+
+FILES_${PN}-ap6256-wifi = " \
+	${nonarch_base_libdir}/firmware/brcm/brcmfmac43456-sdio* \
+"
+
+FILES_${PN}-ap6256-bt = " \
+	${nonarch_base_libdir}/firmware/brcm/BCM4345C5.hcd \
+"
+
+FILES_${PN}-ap6356-wifi = " \
+	${nonarch_base_libdir}/firmware/brcm/fw_bcm4356a2_ag.bin \
+	${nonarch_base_libdir}/firmware/brcm/nvram_ap6356.txt \
+"
+
+FILES_${PN}-ap6356-bt = " \
+	${nonarch_base_libdir}/firmware/brcm/BCM4356A2.hcd \
+"
+
+FILES_${PN}-ap6398s-wifi = " \
+	${nonarch_base_libdir}/firmware/brcm/fw_bcm4359c0_ag.bin \
+	${nonarch_base_libdir}/firmware/brcm/fw_bcm4359c0_ag_p2p.bin \
+	${nonarch_base_libdir}/firmware/brcm/nvram_ap6398s.txt \
+"
+
+FILES_${PN}-ap6398s-bt = " \
+	${nonarch_base_libdir}/firmware/brcm/BCM4359C0.hcd \
+"
+
+FILES_${PN}-rtl8723ds-bt = " \
+	${nonarch_base_libdir}/firmware/rtlbt/rtl8723d_config \
+	${nonarch_base_libdir}/firmware/rtlbt/rtl8723d_fw \
+"
+
+FILES_${PN}-rtl8723du-bt = " \
+	${nonarch_base_libdir}/firmware/rtl8723du_config \
+	${nonarch_base_libdir}/firmware/rtl8723du_fw \
+"
+
+FILES_${PN}-rtl8821cu-bt = " \
+	${nonarch_base_libdir}/firmware/rtl8821cu_config \
+	${nonarch_base_libdir}/firmware/rtl8821cu_fw \
+"
+
+FILES_${PN} = "*"
+
+# Make it depend on all of the split-out packages.
+python () {
+    pn = d.getVar('PN')
+    firmware_pkgs = oe.utils.packages_filter_out_system(d)
+    d.appendVar('RDEPENDS_' + pn, ' ' + ' '.join(firmware_pkgs))
+}
+
+INSANE_SKIP_${PN} += "arch"


### PR DESCRIPTION
…all path to /usr/lib

Using the nonarch_base_libdir variable to change the install path to /usr/lib instead of hardcoding directly to /lib will help us when we enable the usrmerge feature.

We add the entire recipe here from the existing BSP repo because https://github.com/radxa/meta-radxa.git is now a public archive. We must delete this recipe from here when we migrate to the vendor recommended BSP on the kirkstone branch.

Changelog-entry: Use nonarch_base_libdir to install files in /usr/lib instead of /lib for the rkwifibt-firmware recipe