### PR TITLE
balena-image: Set explicit partition size overrides for each machine

### DIFF
--- a/layers/meta-balena-rockpi/recipes-core/images/balena-image.inc
+++ b/layers/meta-balena-rockpi/recipes-core/images/balena-image.inc
@@ -66,3 +66,9 @@ IMAGE_CMD:balenaos-img:append:radxa-zero-s905y2 () {
 
 # Ensure extlinux.conf files are deployed
 do_rootfs_balenaos-img[depends] += " u-boot-rockpi-4:do_build "
+
+BALENA_BOOT_SIZE_radxa-cm3-io-rk3566 = "40960"
+BALENA_STATE_SIZE_radxa-cm3-io-rk3566 = "20480"
+BALENA_BOOT_SIZE_radxa-zero-s905y2 = "40960"
+BALENA_STATE_SIZE_radxa-zero-s905y2 = "20480"
+BALENA_STATE_SIZE_rockpi-4b-rk3399 = "20480"


### PR DESCRIPTION
## Summary
- Explicitly define `IMAGE_ROOTFS_SIZE`, `BALENA_BOOT_SIZE`, and `BALENA_STATE_SIZE` for every machine target in this repo, preserving any existing custom values and applying fallback defaults (327680/40960/20480) where none were previously set.