### PR TITLE
recipes-kernel: rkwifibt-firmware.bb: fix wifi firmware crash in AP mode

### DIFF
--- a/layers/meta-balena-rockpi/recipes-kernel/rkwifibt-firmware/rkwifibt-firmware.bb
+++ b/layers/meta-balena-rockpi/recipes-kernel/rkwifibt-firmware/rkwifibt-firmware.bb
@@ -16,8 +16,9 @@ do_install() {
 
 	install -m 0644 ${S}/ap6212/bcm43438a1.hcd ${D}/${nonarch_base_libdir}/firmware/brcm/BCM43430A1.hcd
 
-	install -m 0644 ${S}/ap6212/fw_bcm43438a1.bin ${D}/${nonarch_base_libdir}/firmware/brcm/brcmfmac43430-sdio.bin
+	install -m 0644 ${S}/brcm/brcmfmac43430-sdio.bin ${D}/${nonarch_base_libdir}/firmware/brcm/brcmfmac43430-sdio.bin
 	install -m 0644 ${S}/ap6212/nvram.txt ${D}/${nonarch_base_libdir}/firmware/brcm/brcmfmac43430-sdio.txt
+	install -m 0644 ${S}/brcm/brcmfmac43430-sdio.clm_blob ${D}/${nonarch_base_libdir}/firmware/brcm/brcmfmac43430-sdio.clm_blob
 }
 
 PACKAGES =+ " \


### PR DESCRIPTION
The onboard BCM43430 wifi firmware (installed from armbian/firmware's ap6212/ dir since #570) is a 2016 build with no CLM blob, which was crashing (brcmf_fw_crashed) a few minutes into AP mode. Switch to the brcm/ files in the same repo instead: a 2021 build plus the CLM blob that was never being installed.

Changelog-entry:recipes-kernel: rkwifibt-firmware.bb: fix wifi firmware crash in AP mode