### PR TITLE
recipes-bsp/u-boot: Disable usb autosuspend

### DIFF
--- a/layers/meta-balena-rockpi/recipes-bsp/u-boot/u-boot_%.bbappend
+++ b/layers/meta-balena-rockpi/recipes-bsp/u-boot/u-boot_%.bbappend
@@ -18,7 +18,7 @@ BALENA_UBOOT_DEVICES = "0 1"
 
 UBOOT_EXTLINUX_LABELS = "balenaOS"
 UBOOT_EXTLINUX_ROOT = "${resin_kernel_root}"
-UBOOT_EXTLINUX_KERNEL_ARGS = "${os_cmdline}"
+UBOOT_EXTLINUX_KERNEL_ARGS = "${os_cmdline} usbcore.autosuspend=-1"
 
 # Ensure this isn't re-used from sstate
 do_deploy[nostamp] = "1"


### PR DESCRIPTION
... because this causes issues for usb peripherals connected to autokit workers.

Changelog-entry: recipes-bsp/u-boot: Disable usb autosuspend